### PR TITLE
Fixes for "NO PATH FOUND" bug

### DIFF
--- a/src/Frame.java
+++ b/src/Frame.java
@@ -266,10 +266,12 @@ public class Frame extends JPanel
 			else if (currentKey == 'e') {
 				int xRollover = e.getX() % size;
 				int yRollover = e.getY() % size;
-
+				int location = pathfinding.searchBorder(mouseBoxX, mouseBoxY);
 				if (endNode == null) {
+					if(location>-1) pathfinding.removeBorder(location);
 					endNode = new Node(e.getX() - xRollover, e.getY() - yRollover);
 				} else {
+					if(location>-1) pathfinding.removeBorder(location);
 					endNode.setXY(e.getX() - xRollover, e.getY() - yRollover);
 				}
 				repaint();


### PR DESCRIPTION
This makes sure that whenever you add an end node above another wall node, it makes sure to remove the wall node from the borders list so it doesn't count the end node as another wall.